### PR TITLE
Set arm position when FWD LS is pressed

### DIFF
--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -145,8 +145,8 @@ public class Arm extends SubsystemBase {
 
     @Override
     public void periodic() {
-        if (isRevLimitSwitchClosed() && DriverStation.isDisabled()) {
-            _leader.setSelectedSensorPosition(angleToTicks(ArmConstants.collectAngle));
+        if (isFwdLimitSwitchClosed()) {
+            _leader.setSelectedSensorPosition(angleToTicks(ArmConstants.midCubeAngle));
         }
         updateSDB();
     }


### PR DESCRIPTION
We want to physically move the "low" hardstop to the mid angle and calibrate on pressing it.
To fix the issue of the chain slipping when the arm moves down and hits the funnel.

This isn't a risk since the LS is recessed within the AFRAME, the only thing we might want to consider is the forces at that point so close to the axis of rotation.